### PR TITLE
Dot not pollute `precompile` config with all assets on Sprockets 4.

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,6 +1,6 @@
 require "bundler/gem_tasks"
 
-rails_versions = %w[3.2 4.1 4.2 5.0]
+rails_versions = %w[3.2 4.1 4.2 5.0 edge]
 
 task :test do
   version = ENV["RAILS_VERSION"] || rails_versions.last

--- a/lib/torba/rails.rb
+++ b/lib/torba/rails.rb
@@ -2,7 +2,9 @@ module Torba
   class Engine < Rails::Engine
     def self.setup(config = Rails.application.config)
       config.assets.paths.concat(Torba.load_path)
-      config.assets.precompile.concat(Torba.non_js_css_logical_paths)
+      unless using_sprockets4?
+        config.assets.precompile.concat(Torba.non_js_css_logical_paths)
+      end
     end
 
     def self.serve_static_files?(config = Rails.application.config)
@@ -25,5 +27,12 @@ module Torba
       require "torba/rake_task"
       Torba::RakeTask.new("torba:pack", :before => "assets:precompile")
     end
+
+    def self.using_sprockets4?
+      require 'sprockets/version' # Required for Rails 3.2.x with Sprockets 2.x.
+      Gem::Version.new(Sprockets::VERSION) >= Gem::Version.new('4.x')
+    end
+
+    private_class_method :using_sprockets4?
   end
 end

--- a/test/edge/Gemfile
+++ b/test/edge/Gemfile
@@ -1,0 +1,8 @@
+source 'https://rubygems.org'
+
+gem 'rails', github: 'rails/rails'
+gem 'sprockets-rails', github: 'rails/sprockets-rails'
+gem 'sprockets', github: 'rails/sprockets'
+gem 'sass-rails', github: 'rails/sass-rails'
+gem 'uglifier', '>= 1.3.0'
+gem 'torba-rails', path: '../..'

--- a/test/edge/Gemfile.lock
+++ b/test/edge/Gemfile.lock
@@ -1,0 +1,158 @@
+GIT
+  remote: git://github.com/rails/rails.git
+  revision: b8d1dbf9933e3d67e15cd06116164286ba15c6a7
+  specs:
+    actioncable (5.0.0.beta3)
+      actionpack (= 5.0.0.beta3)
+      nio4r (~> 1.2)
+      websocket-driver (~> 0.6.1)
+    actionmailer (5.0.0.beta3)
+      actionpack (= 5.0.0.beta3)
+      actionview (= 5.0.0.beta3)
+      activejob (= 5.0.0.beta3)
+      mail (~> 2.5, >= 2.5.4)
+      rails-dom-testing (~> 1.0, >= 1.0.5)
+    actionpack (5.0.0.beta3)
+      actionview (= 5.0.0.beta3)
+      activesupport (= 5.0.0.beta3)
+      rack (~> 2.x)
+      rack-test (~> 0.6.3)
+      rails-dom-testing (~> 1.0, >= 1.0.5)
+      rails-html-sanitizer (~> 1.0, >= 1.0.2)
+    actionview (5.0.0.beta3)
+      activesupport (= 5.0.0.beta3)
+      builder (~> 3.1)
+      erubis (~> 2.7.0)
+      rails-dom-testing (~> 1.0, >= 1.0.5)
+      rails-html-sanitizer (~> 1.0, >= 1.0.2)
+    activejob (5.0.0.beta3)
+      activesupport (= 5.0.0.beta3)
+      globalid (>= 0.3.6)
+    activemodel (5.0.0.beta3)
+      activesupport (= 5.0.0.beta3)
+    activerecord (5.0.0.beta3)
+      activemodel (= 5.0.0.beta3)
+      activesupport (= 5.0.0.beta3)
+      arel (~> 7.0)
+    activesupport (5.0.0.beta3)
+      concurrent-ruby (~> 1.0)
+      i18n (~> 0.7)
+      minitest (~> 5.1)
+      tzinfo (~> 1.1)
+    rails (5.0.0.beta3)
+      actioncable (= 5.0.0.beta3)
+      actionmailer (= 5.0.0.beta3)
+      actionpack (= 5.0.0.beta3)
+      actionview (= 5.0.0.beta3)
+      activejob (= 5.0.0.beta3)
+      activemodel (= 5.0.0.beta3)
+      activerecord (= 5.0.0.beta3)
+      activesupport (= 5.0.0.beta3)
+      bundler (>= 1.3.0, < 2.0)
+      railties (= 5.0.0.beta3)
+      sprockets-rails (>= 2.0.0)
+    railties (5.0.0.beta3)
+      actionpack (= 5.0.0.beta3)
+      activesupport (= 5.0.0.beta3)
+      method_source
+      rake (>= 0.8.7)
+      thor (>= 0.18.1, < 2.0)
+
+GIT
+  remote: git://github.com/rails/sass-rails.git
+  revision: 28907966729276f9585b79ca48c28569e37a1d6c
+  specs:
+    sass-rails (6.0.0.beta1)
+      railties (>= 4.0.0, < 5.0)
+      sass (~> 3.4)
+      sprockets (~> 4.x)
+      sprockets-rails (< 4.0)
+
+GIT
+  remote: git://github.com/rails/sprockets-rails.git
+  revision: 4f4b387ea315ba76048079434d53dd44d5a3b0ce
+  specs:
+    sprockets-rails (3.0.4)
+      actionpack (>= 4.0)
+      activesupport (>= 4.0)
+      sprockets (>= 3.0.0)
+
+GIT
+  remote: git://github.com/rails/sprockets.git
+  revision: cdcd6bf2adb2ea082328a77ff160124eca8117d9
+  specs:
+    sprockets (4.0.0.beta2)
+      concurrent-ruby (~> 1.0)
+      rack (> 1, < 3)
+
+PATH
+  remote: ../..
+  specs:
+    torba-rails (1.0.0)
+      railties (>= 3.2)
+      torba (~> 1.0)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    arel (7.0.0)
+    builder (3.2.2)
+    concurrent-ruby (1.0.1)
+    erubis (2.7.0)
+    execjs (2.6.0)
+    globalid (0.3.6)
+      activesupport (>= 4.1.0)
+    i18n (0.7.0)
+    json (1.8.3)
+    loofah (2.0.3)
+      nokogiri (>= 1.5.9)
+    mail (2.6.4)
+      mime-types (>= 1.16, < 4)
+    method_source (0.8.2)
+    mime-types (3.0)
+      mime-types-data (~> 3.2015)
+    mime-types-data (3.2016.0221)
+    mini_portile2 (2.0.0)
+    minitest (5.8.4)
+    nio4r (1.2.1)
+    nokogiri (1.6.7.2)
+      mini_portile2 (~> 2.0.0.rc2)
+    rack (2.0.0.alpha)
+      json
+    rack-test (0.6.3)
+      rack (>= 1.0)
+    rails-deprecated_sanitizer (1.0.3)
+      activesupport (>= 4.2.0.alpha)
+    rails-dom-testing (1.0.7)
+      activesupport (>= 4.2.0.beta, < 5.0)
+      nokogiri (~> 1.6.0)
+      rails-deprecated_sanitizer (>= 1.0.1)
+    rails-html-sanitizer (1.0.3)
+      loofah (~> 2.0)
+    rake (11.1.2)
+    sass (3.4.22)
+    thor (0.19.1)
+    thread_safe (0.3.5)
+    torba (1.0.0)
+      thor (~> 0.19.1)
+    tzinfo (1.2.2)
+      thread_safe (~> 0.1)
+    uglifier (3.0.0)
+      execjs (>= 0.3.0, < 3)
+    websocket-driver (0.6.3)
+      websocket-extensions (>= 0.1.0)
+    websocket-extensions (0.1.2)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  rails!
+  sass-rails!
+  sprockets!
+  sprockets-rails!
+  torba-rails!
+  uglifier (>= 1.3.0)
+
+BUNDLED WITH
+   1.11.2

--- a/test/edge/Rakefile
+++ b/test/edge/Rakefile
@@ -1,0 +1,6 @@
+# Add your own tasks in files placed in lib/tasks ending in .rake,
+# for example lib/tasks/capistrano.rake, and they will automatically be available to Rake.
+
+require File.expand_path('../config/application', __FILE__)
+
+Rails.application.load_tasks

--- a/test/edge/Torbafile
+++ b/test/edge/Torbafile
@@ -1,0 +1,8 @@
+gh_release "trumbowyg",
+  source: "torba-rb/Trumbowyg",
+  tag: "1.1.6",
+  import: %w[
+    dist/trumbowyg.js
+    dist/ui/trumbowyg.css
+    dist/ui/images/
+  ]

--- a/test/edge/app/assets/config/manifest.js
+++ b/test/edge/app/assets/config/manifest.js
@@ -1,0 +1,2 @@
+//= link_directory ../javascripts .js
+//= link_directory ../stylesheets .css

--- a/test/edge/app/assets/javascripts/application.js
+++ b/test/edge/app/assets/javascripts/application.js
@@ -1,0 +1,2 @@
+//= require trumbowyg/trumbowyg
+//= require_tree .

--- a/test/edge/app/assets/stylesheets/application.scss
+++ b/test/edge/app/assets/stylesheets/application.scss
@@ -1,0 +1,6 @@
+/*
+ *= require_self
+ *= require_tree .
+ */
+
+@import "trumbowyg/trumbowyg";

--- a/test/edge/app/controllers/application_controller.rb
+++ b/test/edge/app/controllers/application_controller.rb
@@ -1,0 +1,5 @@
+class ApplicationController < ActionController::Base
+  # Prevent CSRF attacks by raising an exception.
+  # For APIs, you may want to use :null_session instead.
+  protect_from_forgery with: :exception
+end

--- a/test/edge/app/helpers/application_helper.rb
+++ b/test/edge/app/helpers/application_helper.rb
@@ -1,0 +1,2 @@
+module ApplicationHelper
+end

--- a/test/edge/app/views/layouts/application.html.erb
+++ b/test/edge/app/views/layouts/application.html.erb
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>TorbaTest</title>
+  <%= stylesheet_link_tag    'application', media: 'all' %>
+  <%= csrf_meta_tags %>
+</head>
+<body>
+
+<%= yield %>
+
+</body>
+</html>

--- a/test/edge/bin/rails
+++ b/test/edge/bin/rails
@@ -1,0 +1,4 @@
+#!/usr/bin/env ruby
+APP_PATH = File.expand_path('../../config/application', __FILE__)
+require_relative '../config/boot'
+require 'rails/commands'

--- a/test/edge/config.ru
+++ b/test/edge/config.ru
@@ -1,0 +1,4 @@
+# This file is used by Rack-based servers to start the application.
+
+require ::File.expand_path('../config/environment', __FILE__)
+run Rails.application

--- a/test/edge/config/application.rb
+++ b/test/edge/config/application.rb
@@ -1,0 +1,17 @@
+require File.expand_path('../boot', __FILE__)
+
+require "rails"
+require "action_controller/railtie"
+require "sprockets/railtie"
+
+# Require the gems listed in Gemfile, including any gems
+# you've limited to :test, :development, or :production.
+Bundler.require(*Rails.groups)
+
+module TorbaTest
+  class Application < Rails::Application
+    # Settings in config/environments/* take precedence over those specified here.
+    # Application configuration should go into files in config/initializers
+    # -- all .rb files in that directory are automatically loaded.
+  end
+end

--- a/test/edge/config/boot.rb
+++ b/test/edge/config/boot.rb
@@ -1,0 +1,3 @@
+ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../../Gemfile', __FILE__)
+
+require 'bundler/setup' # Set up gems listed in the Gemfile.

--- a/test/edge/config/cable.yml
+++ b/test/edge/config/cable.yml
@@ -1,0 +1,10 @@
+# Action Cable uses Redis by default to administer connections, channels, and sending/receiving messages over the WebSocket.
+production:
+  adapter: redis
+  url: redis://localhost:6379/1
+
+development:
+  adapter: async
+
+test:
+  adapter: async

--- a/test/edge/config/environment.rb
+++ b/test/edge/config/environment.rb
@@ -1,0 +1,5 @@
+# Load the Rails application.
+require File.expand_path('../application', __FILE__)
+
+# Initialize the Rails application.
+Rails.application.initialize!

--- a/test/edge/config/environments/development.rb
+++ b/test/edge/config/environments/development.rb
@@ -1,0 +1,52 @@
+Rails.application.configure do
+  # Settings specified here will take precedence over those in config/application.rb.
+
+  # In the development environment your application's code is reloaded on
+  # every request. This slows down response time but is perfect for development
+  # since you don't have to restart the web server when you make code changes.
+  config.cache_classes = false
+
+  # Do not eager load code on boot.
+  config.eager_load = false
+
+  # Show full error reports.
+  config.consider_all_requests_local = true
+
+  # Enable/disable caching. By default caching is disabled.
+  if Rails.root.join('tmp/caching-dev.txt').exist?
+    config.action_controller.perform_caching = true
+
+    config.cache_store = :memory_store
+    config.public_file_server.headers = {
+      'Cache-Control' => 'public, max-age=172800'
+    }
+  else
+    config.action_controller.perform_caching = false
+
+    config.cache_store = :null_store
+  end
+
+  # Print deprecation notices to the Rails logger.
+  config.active_support.deprecation = :log
+
+  # Debug mode disables concatenation and preprocessing of assets.
+  # This option may cause significant delays in view rendering with a large
+  # number of complex assets.
+  config.assets.debug = true
+
+  # Asset digests allow you to set far-future HTTP expiration dates on all assets,
+  # yet still be able to expire them through the digest params.
+  config.assets.digest = true
+
+  # Adds additional error checking when serving assets at runtime.
+  # Checks for improperly declared sprockets dependencies.
+  # Raises helpful error messages.
+  config.assets.raise_runtime_errors = true
+
+  # Raises error for missing translations
+  # config.action_view.raise_on_missing_translations = true
+
+  # Use an evented file watcher to asynchronously detect changes in source code,
+  # routes, locales, etc. This feature depends on the listen gem.
+  # config.file_watcher = ActiveSupport::EventedFileUpdateChecker
+end

--- a/test/edge/config/environments/production.rb
+++ b/test/edge/config/environments/production.rb
@@ -1,0 +1,79 @@
+Rails.application.configure do
+  # Settings specified here will take precedence over those in config/application.rb.
+
+  # Code is not reloaded between requests.
+  config.cache_classes = true
+
+  # Eager load code on boot. This eager loads most of Rails and
+  # your application in memory, allowing both threaded web servers
+  # and those relying on copy on write to perform better.
+  # Rake tasks automatically ignore this option for performance.
+  config.eager_load = true
+
+  # Full error reports are disabled and caching is turned on.
+  config.consider_all_requests_local       = false
+  config.action_controller.perform_caching = true
+
+  # Disable serving static files from the `/public` folder by default since
+  # Apache or NGINX already handles this.
+  config.public_file_server.enabled = ENV['RAILS_SERVE_STATIC_FILES'].present?
+
+  # Compress JavaScripts and CSS.
+  config.assets.js_compressor = :uglifier
+  # config.assets.css_compressor = :sass
+
+  # Do not fallback to assets pipeline if a precompiled asset is missed.
+  config.assets.compile = false
+
+  # Asset digests allow you to set far-future HTTP expiration dates on all assets,
+  # yet still be able to expire them through the digest params.
+  config.assets.digest = true
+
+  # `config.assets.precompile` and `config.assets.version` have moved to config/initializers/assets.rb
+
+  # Enable serving of images, stylesheets, and JavaScripts from an asset server.
+  # config.action_controller.asset_host = 'http://assets.example.com'
+
+  # Specifies the header that your server uses for sending files.
+  # config.action_dispatch.x_sendfile_header = 'X-Sendfile' # for Apache
+  # config.action_dispatch.x_sendfile_header = 'X-Accel-Redirect' # for NGINX
+
+  # Action Cable endpoint configuration
+  # config.action_cable.url = 'wss://example.com/cable'
+  # config.action_cable.allowed_request_origins = [ 'http://example.com', /http:\/\/example.*/ ]
+
+  # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
+  # config.force_ssl = true
+
+  # Use the lowest log level to ensure availability of diagnostic information
+  # when problems arise.
+  config.log_level = :debug
+
+  # Prepend all log lines with the following tags.
+  config.log_tags = [ :request_id ]
+
+  # Use a different logger for distributed setups.
+  # require 'syslog/logger'
+  # config.logger = ActiveSupport::TaggedLogging.new(Syslog::Logger.new 'app-name')
+
+  if ENV["RAILS_LOG_TO_STDOUT"].present?
+    config.logger = ActiveSupport::TaggedLogging.new(Logger.new(STDOUT))
+  end
+
+  # Use a different cache store in production.
+  # config.cache_store = :mem_cache_store
+
+  # Ignore bad email addresses and do not raise email delivery errors.
+  # Set this to true and configure the email server for immediate delivery to raise delivery errors.
+  # config.action_mailer.raise_delivery_errors = false
+
+  # Enable locale fallbacks for I18n (makes lookups for any locale fall back to
+  # the I18n.default_locale when a translation cannot be found).
+  config.i18n.fallbacks = true
+
+  # Send deprecation notices to registered listeners.
+  config.active_support.deprecation = :notify
+
+  # Use default logging formatter so that PID and timestamp are not suppressed.
+  config.log_formatter = ::Logger::Formatter.new
+end

--- a/test/edge/config/environments/test.rb
+++ b/test/edge/config/environments/test.rb
@@ -1,0 +1,36 @@
+Rails.application.configure do
+  # Settings specified here will take precedence over those in config/application.rb.
+
+  # The test environment is used exclusively to run your application's
+  # test suite. You never need to work with it otherwise. Remember that
+  # your test database is "scratch space" for the test suite and is wiped
+  # and recreated between test runs. Don't rely on the data there!
+  config.cache_classes = true
+
+  # Do not eager load code on boot. This avoids loading your whole application
+  # just for the purpose of running a single test. If you are using a tool that
+  # preloads Rails for running tests, you may have to set it to true.
+  config.eager_load = false
+
+  # Configure public file server for tests with Cache-Control for performance.
+  config.public_file_server.enabled = true
+  config.public_file_server.headers = {
+    'Cache-Control' => 'public, max-age=3600'
+  }
+
+  # Show full error reports and disable caching.
+  config.consider_all_requests_local       = true
+  config.action_controller.perform_caching = false
+
+  # Raise exceptions instead of rendering exception templates.
+  config.action_dispatch.show_exceptions = false
+
+  # Disable request forgery protection in test environment.
+  config.action_controller.allow_forgery_protection = false
+
+  # Print deprecation notices to the stderr.
+  config.active_support.deprecation = :stderr
+
+  # Raises error for missing translations
+  # config.action_view.raise_on_missing_translations = true
+end

--- a/test/edge/config/initializers/assets.rb
+++ b/test/edge/config/initializers/assets.rb
@@ -1,0 +1,11 @@
+# Be sure to restart your server when you modify this file.
+
+# Version of your assets, change this if you want to expire all your assets.
+Rails.application.config.assets.version = '1.0'
+
+# Add additional assets to the asset load path
+# Rails.application.config.assets.paths << Emoji.images_path
+
+# Precompile additional assets.
+# application.js, application.css, and all non-JS/CSS in app/assets folder are already added.
+# Rails.application.config.assets.precompile += %w( search.js )

--- a/test/edge/config/initializers/cookies_serializer.rb
+++ b/test/edge/config/initializers/cookies_serializer.rb
@@ -1,0 +1,5 @@
+# Be sure to restart your server when you modify this file.
+
+# Specify a serializer for the signed and encrypted cookie jars.
+# Valid options are :json, :marshal, and :hybrid.
+Rails.application.config.action_dispatch.cookies_serializer = :json

--- a/test/edge/config/initializers/filter_parameter_logging.rb
+++ b/test/edge/config/initializers/filter_parameter_logging.rb
@@ -1,0 +1,4 @@
+# Be sure to restart your server when you modify this file.
+
+# Configure sensitive parameters which will be filtered from the log file.
+Rails.application.config.filter_parameters += [:password]

--- a/test/edge/config/initializers/per_form_csrf_tokens.rb
+++ b/test/edge/config/initializers/per_form_csrf_tokens.rb
@@ -1,0 +1,4 @@
+# Be sure to restart your server when you modify this file.
+
+# Enable per-form CSRF tokens.
+Rails.application.config.action_controller.per_form_csrf_tokens = true

--- a/test/edge/config/initializers/request_forgery_protection.rb
+++ b/test/edge/config/initializers/request_forgery_protection.rb
@@ -1,0 +1,4 @@
+# Be sure to restart your server when you modify this file.
+
+# Enable origin-checking CSRF mitigation.
+Rails.application.config.action_controller.forgery_protection_origin_check = true

--- a/test/edge/config/initializers/session_store.rb
+++ b/test/edge/config/initializers/session_store.rb
@@ -1,0 +1,3 @@
+# Be sure to restart your server when you modify this file.
+
+Rails.application.config.session_store :cookie_store, key: '_torba_test_session'

--- a/test/edge/config/initializers/wrap_parameters.rb
+++ b/test/edge/config/initializers/wrap_parameters.rb
@@ -1,0 +1,14 @@
+# Be sure to restart your server when you modify this file.
+
+# This file contains settings for ActionController::ParamsWrapper which
+# is enabled by default.
+
+# Enable parameter wrapping for JSON. You can disable this by setting :format to an empty array.
+ActiveSupport.on_load(:action_controller) do
+  wrap_parameters format: [:json]
+end
+
+# To enable root element in JSON for ActiveRecord objects.
+# ActiveSupport.on_load(:active_record) do
+#   self.include_root_in_json = true
+# end

--- a/test/edge/config/locales/en.yml
+++ b/test/edge/config/locales/en.yml
@@ -1,0 +1,23 @@
+# Files in the config/locales directory are used for internationalization
+# and are automatically loaded by Rails. If you want to use locales other
+# than English, add the necessary files in this directory.
+#
+# To use the locales, use `I18n.t`:
+#
+#     I18n.t 'hello'
+#
+# In views, this is aliased to just `t`:
+#
+#     <%= t('hello') %>
+#
+# To use a different locale, set it with `I18n.locale`:
+#
+#     I18n.locale = :es
+#
+# This would use the information in config/locales/es.yml.
+#
+# To learn more, please read the Rails Internationalization guide
+# available at http://guides.rubyonrails.org/i18n.html.
+
+en:
+  hello: "Hello world"

--- a/test/edge/config/puma.rb
+++ b/test/edge/config/puma.rb
@@ -1,0 +1,47 @@
+# Puma can serve each request in a thread from an internal thread pool.
+# The `threads` method setting takes two numbers a minimum and maximum.
+# Any libraries that use thread pools should be configured to match
+# the maximum value specified for Puma. Default is set to 5 threads for minimum
+# and maximum, this matches the default thread size of Active Record.
+#
+threads_count = ENV.fetch("RAILS_MAX_THREADS") { 5 }.to_i
+threads threads_count, threads_count
+
+# Specifies the `port` that Puma will listen on to receive requests, default is 3000.
+#
+port        ENV.fetch("PORT") { 3000 }
+
+# Specifies the `environment` that Puma will run in.
+#
+environment ENV.fetch("RAILS_ENV") { "development" }
+
+# Specifies the number of `workers` to boot in clustered mode.
+# Workers are forked webserver processes. If using threads and workers together
+# the concurrency of the application would be max `threads` * `workers`.
+# Workers do not work on JRuby or Windows (both of which do not support
+# processes).
+#
+# workers ENV.fetch("WEB_CONCURRENCY") { 2 }
+
+# Use the `preload_app!` method when specifying a `workers` number.
+# This directive tells Puma to first boot the application and load code
+# before forking the application. This takes advantage of Copy On Write
+# process behavior so workers use less memory. If you use this option
+# you need to make sure to reconnect any threads in the `on_worker_boot`
+# block.
+#
+# preload_app!
+
+# The code in the `on_worker_boot` will be called if you are using
+# clustered mode by specifying a number of `workers`. After each worker
+# process is booted this block will be run, if you are using `preload_app!`
+# option you will want to use this block to reconnect to any threads
+# or connections that may have been created at application boot, Ruby
+# cannot share connections between processes.
+#
+# on_worker_boot do
+#   ActiveRecord::Base.establish_connection if defined?(ActiveRecord)
+# end
+
+# Allow puma to be restarted by `rails restart` command.
+plugin :tmp_restart

--- a/test/edge/config/routes.rb
+++ b/test/edge/config/routes.rb
@@ -1,0 +1,6 @@
+Rails.application.routes.draw do
+  # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
+
+  # Serve websocket cable requests in-process
+  # mount ActionCable.server => '/cable'
+end

--- a/test/edge/config/secrets.yml
+++ b/test/edge/config/secrets.yml
@@ -1,0 +1,22 @@
+# Be sure to restart your server when you modify this file.
+
+# Your secret key is used for verifying the integrity of signed cookies.
+# If you change this key, all old signed cookies will become invalid!
+
+# Make sure the secret is at least 30 characters and all random,
+# no regular words or you'll be exposed to dictionary attacks.
+# You can use `rake secret` to generate a secure secret key.
+
+# Make sure the secrets in this file are kept private
+# if you're sharing your code publicly.
+
+development:
+  secret_key_base: 3c3d4f90a7f43a6ff4aa84bbc404d6d0294e494046c4b310714de80aac2dbcaa6c2b11e83821e3216442c318fc3c2b83d1090a558fc878488efd4c67a6551195
+
+test:
+  secret_key_base: 5a3daec7e70d5b20a8f7385a1d2bee36951ade36ef335dcb4513b7b4172a58f9e355719edcbdd04aa1be24a324753f45ca49920f25d5e883554ca3ebdb5a5730
+
+# Do not keep production secrets in the repository,
+# instead read values from the environment.
+production:
+  secret_key_base: <%= ENV["SECRET_KEY_BASE"] %>

--- a/test/edge/db/seeds.rb
+++ b/test/edge/db/seeds.rb
@@ -1,0 +1,7 @@
+# This file should contain all the record creation needed to seed the database with its default values.
+# The data can then be loaded with the rake db:seed (or created alongside the db with db:setup).
+#
+# Examples:
+#
+#   cities = City.create([{ name: 'Chicago' }, { name: 'Copenhagen' }])
+#   Mayor.create(name: 'Emanuel', city: cities.first)


### PR DESCRIPTION
Precompiled assets should be linked through the `app/assets/config/manifest.js`
instead.

I've added a whole new Rails app for edge testing to not get in the way of apps that are still using Sprockets 3.

Port of torba-rb/torba#19
