### PR TITLE
Improve Travis setup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,12 @@
+sudo: false
+cache: bundler
 language: ruby
 rvm:
   - 2.2.2
+  - 2.3.0
 bundler_args: --without doc debug
+env:
+  matrix:
+    - RAILS_VERSION=3.2
+    - RAILS_VERSION=4.2
+    - RAILS_VERSION=5.0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,8 +36,14 @@
 ## Running the tests
 
 ```
-bundle exec rake bundle
-bundle exec rake test_all
+# Runs the test suite against the latest version of Rails.
+bundle exec rake test
+
+# Runs the test suite for a specific version of Rails.
+bundle exec rake test RAILS_VERSION=4.2
+
+# Runs the test suite for all supported versions of Rails.
+bundle exec rake
 ```
 
 ## Working with documentation

--- a/Rakefile
+++ b/Rakefile
@@ -2,25 +2,20 @@ require "bundler/gem_tasks"
 
 rails_versions = %w[3.2 4.2 5.0]
 
-task :bundle do
-  rails_versions.each do |version|
-    Bundler.with_clean_env do
-      sh "BUNDLE_GEMFILE=test/#{version}/Gemfile bundle install"
-    end
-  end
-end
-
 task :test do
+  version = ENV["RAILS_VERSION"] || rails_versions.last
+  Bundler.with_clean_env do
+    sh "BUNDLE_GEMFILE=test/#{version}/Gemfile bundle install"
+  end
+
   $LOAD_PATH.unshift("test")
   Dir.glob("./test/**/*_test.rb").each { |file| require file}
 end
 
 task :test_all do
   rails_versions.each do |version|
-    Bundler.with_clean_env do
-      sh "RAILS_VERSION=#{version} bundle exec rake test"
-    end
+    exit 1 unless sh "bundle exec rake test RAILS_VERSION=#{version}"
   end
 end
 
-task :default => [:bundle, :test_all]
+task :default => :test_all


### PR DESCRIPTION
* Disable `sudo` and enable Bundler caching.
* Test against Ruby 2.3.
* Split the multi Rails test suite into multiple jobs, so they can be executed
  in parallel and we can flag unstable versions and allowed failures in the future.
* `rake test` now bundles the specified Rails version dependencies automatically,
  so `rake bundle` isn't required anymore.