### PR TITLE
Use latest version of Torba

### DIFF
--- a/torba-rails.gemspec
+++ b/torba-rails.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^bin/}).map{ |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "torba", "~> 1.0"
+  spec.add_dependency "torba", "~> 1.2"
   spec.add_dependency "railties", ">= 3.2"
 
   spec.add_development_dependency "bundler"


### PR DESCRIPTION
Latest version of Torba has some important bug fixes and should be used in latest version of torba-rails.

One specific significant fix is correct handling of namespaced npm packages, e.g. `@hotwired/turbo`.